### PR TITLE
Fix issues with config and incompatible Mixin (fixes #4)

### DIFF
--- a/src/main/java/me/simon/config/Config.java
+++ b/src/main/java/me/simon/config/Config.java
@@ -3,8 +3,6 @@ package me.simon.config;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import net.fabricmc.loader.api.FabricLoader;
-import org.apache.commons.logging.Log;
-
 
 import java.io.*;
 
@@ -19,26 +17,25 @@ public class Config {
 
     public void save() throws IOException {
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
-        File config = new File("config/color.json");
-        if(!config.exists()){
-            config.mkdirs();
-            config.createNewFile();
-        }
-        try (FileWriter file = new FileWriter("config/color.json")) {
+        File config = new File(FabricLoader.getInstance().getConfigDirectory(), "color.json");
+        try (FileWriter file = new FileWriter(config)) {
             file.write(gson.toJson(this));
-        } catch (IOException e) {
-            e.printStackTrace();
         }
     }
 
     public void load() throws IOException{
-        File config1 = new File("config/color.json");
+        File config1 = new File(FabricLoader.getInstance().getConfigDirectory(), "color.json");
         if(!config1.exists()){
             this.save();
+            return;
         }
-        FileReader reader;
-        try {
-            reader = new FileReader("config/color.json");
+        if (config1.isDirectory()) {
+            if (config1.delete()) {
+                this.save();
+                return;
+            }
+        }
+        try (FileReader reader = new FileReader(config1)) {
             Gson gson = new GsonBuilder().setPrettyPrinting().create();
             Config config = gson.fromJson(reader, Config.class);
             this.enableColor = config.enableColor;
@@ -47,10 +44,8 @@ public class Config {
             this.motd = config.motd;
             this.enableTablistFormatting = config.enableTablistFormatting;
             if(config.configVersion != this.configVersion){
-                config1.delete();
-                this.load();
+                this.save();
             }
-            this.save();
         } catch (FileNotFoundException e) {
             e.printStackTrace();
         }

--- a/src/main/java/me/simon/mixins/PlayerListMixin.java
+++ b/src/main/java/me/simon/mixins/PlayerListMixin.java
@@ -1,26 +1,17 @@
 package me.simon.mixins;
 
-import me.simon.Main;
-import me.simon.commands.util.TextFormatter;
-import me.simon.config.Config;
+import net.minecraft.network.Packet;
+import net.minecraft.network.listener.ClientPlayPacketListener;
 import net.minecraft.network.packet.s2c.play.PlayerListHeaderS2CPacket;
-import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.gen.Accessor;
 
 @Mixin(PlayerListHeaderS2CPacket.class)
-public class PlayerListMixin {
-    @Shadow private Text footer;
+public interface PlayerListMixin extends Packet<ClientPlayPacketListener> {
+    @Accessor
+    void setFooter(Text footer);
 
-    @Shadow private Text header;
-
-    @Inject(at= @At("RETURN"), method = "<init>")
-    public void PlayerListHeaderS2CPacket(CallbackInfo ci) {
-        this.footer = new LiteralText(TextFormatter.tablistChars(Config.INSTANCE.footer));
-        this.header = new LiteralText(TextFormatter.tablistChars(Config.INSTANCE.header));
-    }
+    @Accessor
+    void setHeader(Text header);
 }

--- a/src/main/java/me/simon/mixins/PlayerManagerMixin.java
+++ b/src/main/java/me/simon/mixins/PlayerManagerMixin.java
@@ -1,10 +1,8 @@
 package me.simon.mixins;
 
-import io.netty.buffer.ByteBuf;
-import me.simon.Main;
+import me.simon.commands.util.TextFormatter;
 import me.simon.config.Config;
 import net.minecraft.network.ClientConnection;
-import net.minecraft.network.MessageType;
 import net.minecraft.network.Packet;
 import net.minecraft.network.packet.s2c.play.PlayerListHeaderS2CPacket;
 import net.minecraft.server.PlayerManager;
@@ -24,7 +22,11 @@ public abstract class PlayerManagerMixin {
     @Inject(at= @At("HEAD"), method = "updatePlayerLatency")
     public void updatePlayerLatency(CallbackInfo ci) {
         if(Config.INSTANCE.enableTablistFormatting) {
-            this.sendToAll(new PlayerListHeaderS2CPacket());
+            @SuppressWarnings("ConstantConditions")
+            PlayerListMixin packet = (PlayerListMixin) new PlayerListHeaderS2CPacket();
+            packet.setFooter(new LiteralText(TextFormatter.tablistChars(Config.INSTANCE.footer)));
+            packet.setHeader(new LiteralText(TextFormatter.tablistChars(Config.INSTANCE.header)));
+            this.sendToAll(packet);
         }
     }
 


### PR DESCRIPTION
The existing code seems to make a directory `config/color.json/` rather than the directory `config/` but `FabricLoader.getInstance().getConfigDirectory()` creates the config folder for you, you can just use that. I also added some code to remove the directory if it does exist, and cleaned up the config version logic (the previous code seems like it would cause infinite recursion).

I also noticed that `PlayerListMixin` hardcodes the value of any `PlayerListHeaderS2CPacket` created by any mod - so I changed it to use an accessor mixin and set the values in the calling code.